### PR TITLE
Feature/disable buttons

### DIFF
--- a/puppeteerTesting/dashboardE2E.test.js
+++ b/puppeteerTesting/dashboardE2E.test.js
@@ -21,11 +21,11 @@
   });
 
   /**
-   * Check to make sure "+ New" button should redirect to the note editor window
+   * Check to make sure "+ New Note" button should redirect to the note editor window
    */
-  it('Checking to make sure "+ New" button should redirect to note editor page', async () => {
+  it('Checking to make sure "+ New Note" button should redirect to note editor page', async () => {
     
-    console.log('Checking "+ New" button...');
+    console.log('Checking "+ New Note" button...');
     const newButton = await page.$('button');
     await newButton.click();
     await page.waitForNavigation(); 
@@ -70,7 +70,7 @@
   it('Checking to make sure the Note text area has no input initially', async () => {
 
     console.log('Checking to make sure the Note text area has no input initially');
-    const noteTextArea = await page.$eval('#notes-content-input',e => e.value);
+    const noteTextArea = await page.$eval('#edit-content',e => e.value);
     expect(noteTextArea).toBe('');
   }, 2500);
 
@@ -80,11 +80,11 @@
     it('Check to make sure the text area input is changed from empty to 5 lines', async () => {
 
     console.log('Checking to make sure the title input is now "Lecture 1 CSE 110"...');
-    var inputTxt = await page.$('#notes-content-input');
+    var inputTxt = await page.$('#edit-content');
     await inputTxt.click({clickCount: 2});
-    await page.type('#notes-content-input','Lecture 1 CSE 110. ' +
+    await page.type('#edit-content','Lecture 1 CSE 110. ' +
     'Hello this is my first note!');
-    titleText = await page.$eval('#notes-content-input', e => e.value);
+    titleText = await page.$eval('#edit-content', e => e.value);
     expect(titleText).toBe('Lecture 1 CSE 110. Hello this is my first note!');
 
   }, 100000);
@@ -94,12 +94,12 @@
   it('Check to make sure "Save" button should redirect to the note view editor mode window', async () => {
     
     console.log('Checking "Save" button...');
-    const newButton = await page.$('button');
+    const newButton = await page.$('#save-button');
     await newButton.click();
     await page.waitForNavigation(); 
-    expect(page.url()).toBe('https://cse110-fa22-group5.github.io/cse110-fa22-group5/source/notes.html?id=1$preview=true');
+    expect(page.url()).toBe('https://cse110-fa22-group5.github.io/cse110-fa22-group5/source/notes.html?id=1');
 
-  }, 2500);
+  }, 10000);
 
 /**
  * Check to make sure after clicking Save the notes-title innerHTML for the title is 'Lecture 1 CSE 110'
@@ -107,7 +107,7 @@
     it('Check to make sure after clicking Save the window is in view editor mode and user cannot edit note page', async () => {
 
     console.log('Checking title input uneditable...');
-    const titleText = await page.$eval('#notes-title',e => e.innerHTML);
+    const titleText = await page.$eval('#title-input',e => e.value);
     console.log(titleText);
     expect(titleText).toBe('Lecture 1 CSE 110');
     
@@ -119,8 +119,8 @@
   it('Check to make sure the note content body "disabled" attribute is on', async () => {
 
   console.log('Checking that note content input disabled attribute is on...');
-  const notesDisabled = await page.$eval('#notes-content-input',e => e.getAttribute('disabled'));
-  expect(notesDisabled).toBe('disabled');
+  const notesDisabled = await page.$eval('#view-content > p',e => e.innerText);
+  expect(notesDisabled).toBe('Lecture 1 CSE 110. Hello this is my first note!');
   
 }, 2500);  
 
@@ -130,7 +130,7 @@
    it('Check to make sure the "Edit button" is on the page on view mode ', async () => {
 
     console.log('Making sure the "Edit button" is on the page on view mode ...');
-    const editButton = await page.$('button');
+    const editButton = await page.$('#change-view-button');
     const editB = await editButton.getProperty('innerText');
     const editBVal = await editB.jsonValue();
     expect(editBVal).toBe('Edit');
@@ -143,15 +143,14 @@
     it('Check to make sure when you click the "Edit" button, title is now editable', async () => {
 
     console.log('Check to make sure title is now editable ...');
-    const editButton = await page.$('button');
+    const editButton = await page.$('#change-view-button');
     await editButton.click();
-    await page.waitForNavigation();
-    const titleText = await page.$eval('#notes-title',e => e.innerText);
+    const titleText = await page.$eval('#notes-title',e => e.innerHTML);
     console.log(titleText);
-    expect(titleText).toBe('Title: ');
+    expect(titleText).toBe('<input type="text" id="title-input" name="title-input">');
     
     
-  }, 2500);  
+  }, 1000 );  
 
 /**
  * Check to make sure title is now 'Lecture 1 & Discussion: CSE 110'
@@ -171,10 +170,12 @@
 */
     it('Check to make sure note body is changed', async () => {
 
-    var inputTxt = await page.$('#notes-content-input');
+    var inputTxt = await page.$('#edit-content');
     await inputTxt.click({clickCount: 1});
-    await page.type('#notes-content-input',' Adding discussion text');
-    var titleText = await page.$eval('#notes-content-input', e => e.value);
+    await page.type('#edit-content',' Adding discussion text');
+    const viewButton = await page.$('#change-view-button');
+    await viewButton.click();
+    var titleText = await page.$eval('#view-content > p', e => e.innerText);
     expect(titleText).toBe('Lecture 1 CSE 110. Hello this is my first note! Adding discussion text');
     
   }, 10000);  
@@ -186,10 +187,10 @@
 it('Clicking "Save note" to go back to view mode, check preview in the url is false', async () => {
 
 console.log('Checking window url from "Save" button...');
-const newButton = await page.$('button');
+const newButton = await page.$('#save-button');
 await newButton.click();
-await page.waitForNavigation(); 
-expect(page.url()).toBe('https://cse110-fa22-group5.github.io/cse110-fa22-group5/source/notes.html?id=1$preview=true');
+page.waitForNavigation(); 
+expect(page.url()).toBe('https://cse110-fa22-group5.github.io/cse110-fa22-group5/source/notes.html?id=1');
 
 }, 10000); 
 

--- a/source/notes.html
+++ b/source/notes.html
@@ -18,7 +18,7 @@
             <a href="./index.html" id="back-button"><i class="fa fa-arrow-left" aria-hidden="true"></i></a>
             <button id="change-view-button">Edit</button>
             <button id="save-button">Save</button>
-            <button id="delete-button" hidden>Delete</button>
+            <button id="delete-button">Delete</button>
         </div>
         
         <div id="subheader">

--- a/source/notes.html
+++ b/source/notes.html
@@ -18,7 +18,7 @@
             <a href="./index.html" id="back-button"><i class="fa fa-arrow-left" aria-hidden="true"></i></a>
             <button id="change-view-button">Edit</button>
             <button id="save-button">Save</button>
-            <button id="delete-button">Delete</button>
+            <button id="delete-button" hidden>Delete</button>
         </div>
         
         <div id="subheader">

--- a/source/scripts/notesEditor.js
+++ b/source/scripts/notesEditor.js
@@ -25,9 +25,6 @@ async function init() {
     }
     //if id doesn't exist meaning it's a new note, only edit mode
     if (!id) {
-        const deleteButton = document.querySelector('#delete-button');
-        deleteButton.hidden = true;
-
         let noteObject = {
             "title": "Untitled Note",
             "lastModified": `${getDate()}`,
@@ -37,6 +34,9 @@ async function init() {
         initEditToggle(true);
     } else {
         //if id exists meaning it's an existing note, pass preview to enable edit mode button
+        const deleteButton = document.querySelector('#delete-button');
+        deleteButton.hidden = false;
+
         id = parseInt(id);
         let note = await getNoteFromStorage(db, parseInt(id));
         await addNotesToDocument(note);

--- a/source/scripts/notesEditor.js
+++ b/source/scripts/notesEditor.js
@@ -25,6 +25,11 @@ async function init() {
     }
     //if id doesn't exist meaning it's a new note, only edit mode
     if (!id) {
+        const deleteButton = document.querySelector('#delete-button');
+        const editButton = document.querySelector('#change-view-button');
+        deleteButton.hidden = true;
+        editButton.hidden = true;
+
         let noteObject = {
             "title": "Untitled Note",
             "lastModified": `${getDate()}`,
@@ -39,6 +44,7 @@ async function init() {
         await addNotesToDocument(note);
         initEditToggle(false);
     }
+
     initDeleteButton(id, db);
     initSaveButton(id, db);
 }
@@ -65,10 +71,14 @@ function getDate() {
  */
  function initEditToggle(editEnabled) {
     const editButton = document.querySelector('#change-view-button');
+    const saveButton = document.querySelector('#save-button');
+
     if (editEnabled) {
         editButton.innerHTML = 'Preview';
+        saveButton.hidden = false;
     } else {
-        editButton.innerHTML = 'Edit'
+        editButton.innerHTML = 'Edit';
+        saveButton.hidden = true;
     }
     setEditable(editEnabled);
     editButton.onclick = async () => {
@@ -111,6 +121,7 @@ function initSaveButton(id, db) {
             });
         }
         // Switch to preview mode
+        initEditToggle(false);
         setEditable(false);
     });
 }
@@ -159,14 +170,18 @@ async function setEditable(editable) {
     let editContent = document.querySelector('#edit-content');
     let viewContent = document.querySelector('#view-content');
     let titleInput = document.querySelector('#title-input');
+    const saveButton = document.querySelector('#save-button');
+
     if (!editable) {
         viewContent.innerHTML = markdown(editContent.value);
         viewContent.hidden = false;
         editContent.hidden = true;
         titleInput.setAttribute('disabled', true);
+        saveButton.hidden = true;
     } else {
         editContent.hidden = false;
         viewContent.hidden = true;
         titleInput.removeAttribute('disabled');
+        saveButton.hidden = false;
     }
 }

--- a/source/scripts/notesEditor.js
+++ b/source/scripts/notesEditor.js
@@ -73,10 +73,12 @@ function getDate() {
 
     if (editEnabled) {
         editButton.innerHTML = 'Preview';
-        saveButton.hidden = false;
+        saveButton.classList.remove('disabled-button');
+        saveButton.disabled = false;
     } else {
         editButton.innerHTML = 'Edit';
-        saveButton.hidden = true;
+        saveButton.classList.add('disabled-button');
+        saveButton.disabled = true;
     }
     setEditable(editEnabled);
     editButton.onclick = async () => {
@@ -175,11 +177,13 @@ async function setEditable(editable) {
         viewContent.hidden = false;
         editContent.hidden = true;
         titleInput.setAttribute('disabled', true);
-        saveButton.hidden = true;
+        saveButton.classList.add('disabled-button');
+        saveButton.disabled = true;
     } else {
         editContent.hidden = false;
         viewContent.hidden = true;
         titleInput.removeAttribute('disabled');
-        saveButton.hidden = false;
+        saveButton.classList.remove('disabled-button');
+        saveButton.disabled = false;
     }
 }

--- a/source/scripts/notesEditor.js
+++ b/source/scripts/notesEditor.js
@@ -26,9 +26,7 @@ async function init() {
     //if id doesn't exist meaning it's a new note, only edit mode
     if (!id) {
         const deleteButton = document.querySelector('#delete-button');
-        const editButton = document.querySelector('#change-view-button');
         deleteButton.hidden = true;
-        editButton.hidden = true;
 
         let noteObject = {
             "title": "Untitled Note",

--- a/source/scripts/notesEditor.js
+++ b/source/scripts/notesEditor.js
@@ -24,6 +24,7 @@ async function init() {
         id = urlArray[1];
     }
     //if id doesn't exist meaning it's a new note, only edit mode
+    const deleteButton = document.querySelector('#delete-button');
     if (!id) {
         let noteObject = {
             "title": "Untitled Note",
@@ -32,10 +33,11 @@ async function init() {
         };
         await addNotesToDocument(noteObject);
         initEditToggle(true);
+        deleteButton.classList.add('disabled-button');
+        deleteButton.disabled = true;
     } else {
         //if id exists meaning it's an existing note, pass preview to enable edit mode button
-        const deleteButton = document.querySelector('#delete-button');
-        deleteButton.hidden = false;
+        deleteButton.disabled = false;
 
         id = parseInt(id);
         let note = await getNoteFromStorage(db, parseInt(id));
@@ -116,7 +118,7 @@ function initSaveButton(id, db) {
         saveNoteToStorage(db, noteObject);
         if (!id) {
             // Navigate to the saved note page if we're saving a brand new note
-            getNotesFromStorage(db).then(res => {
+            getNotesFromStorage(db).then(res => { 
                 window.location.href = `./notes.html?id=${res[res.length - 1].uuid}`;
             });
         }

--- a/source/styling/notes.css
+++ b/source/styling/notes.css
@@ -155,3 +155,16 @@ main {
 #edit-content {
     border-color: rgba(136, 86, 174, 0.388);
 }
+
+/*Disabled Button*/
+.disabled-button {
+    background-color: gray;
+    color: black;
+    opacity: 20%;
+}
+
+.disabled-button:hover {
+    background-color: gray;
+    color: black;
+    opacity: 20%;
+}


### PR DESCRIPTION
- Fixed buttons so that edit button appears once user saves and enters preview mode
- Disable save button when a user is in preview mode
- When creating new note, delete button only appears after user clicks save the first time and actually creates the note

Preview mode:
<img width="1476" alt="Screen Shot 2022-11-28 at 7 03 25 PM" src="https://user-images.githubusercontent.com/86620096/204429117-9c3f59ad-4983-4465-90fe-0155ea3512e7.png">

Edit mode:
<img width="1471" alt="Screen Shot 2022-11-28 at 7 03 33 PM" src="https://user-images.githubusercontent.com/86620096/204429140-701bed89-4134-433d-8618-646c634e10c1.png">

Before note has actually been saved and created:
<img width="1478" alt="Screen Shot 2022-11-28 at 7 06 02 PM" src="https://user-images.githubusercontent.com/86620096/204429213-a92aaf4e-fc1b-453a-a9d8-00060165dd64.png">
