### PR TITLE
Confirm deletion of note

### DIFF
--- a/source/scripts/dashboardRow.js
+++ b/source/scripts/dashboardRow.js
@@ -82,9 +82,14 @@ class dashboardRow extends HTMLElement{
         let button = shadow.querySelector('.note > div > button');
         button.addEventListener('click', async (event)=>{
             event.stopPropagation();
-            const db = await initializeDB(indexedDB);
-            deleteNoteFromStorage(db, note);
-            location.reload();
+            // confirm note deletion with user
+            if (confirm("Are you sure you want to delete this note?")) {
+                const db = await initializeDB(indexedDB);
+                deleteNoteFromStorage(db, note);
+                location.reload();
+            } else {
+                // do nothing if user does not confirm deletion
+            }
         })
         noteDiv.onclick = () => {
             window.location.href = `./notes.html?id=${note.uuid}`;

--- a/source/scripts/notesEditor.js
+++ b/source/scripts/notesEditor.js
@@ -140,9 +140,14 @@ function initDeleteButton(id, db) {
         if (id) {
             // Only do this if the id has already been saved; 
             // otherwise return directly to the dashboard
-            deleteNoteFromStorage(db, { uuid: id });
+            if (confirm("Are you sure you want to delete this note?")) {
+                deleteNoteFromStorage(db, { uuid: id });
+                window.location.href = './index.html';
+            } else {
+
+            }
         }
-        window.location.href = './index.html';
+        
     });
 }
 


### PR DESCRIPTION
Closes #85 
When clicking delete button on a note in the dashboard, a user is alerted and must confirm deletion first.
<img width="1219" alt="Screen Shot 2022-11-29 at 4 33 15 PM" src="https://user-images.githubusercontent.com/86620096/204678817-abb80226-57ed-47dd-ae3d-8d663806a90e.png">
