### PR TITLE
Documentation/jsdocs readme

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,13 +28,14 @@ jobs:
           source_dir: ./source/scripts
           recurse: true
           output_dir: ./jsdocs
+          front_page: README.md
 
       # Push generated files onto a new branch called gh-pages
       - name: Deploy jsDocs
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./jsdocs
+          publish_dir: .
 
       - name: HTML5 Validator
         uses: Cyb3r-Jak3/html5validator-action@v7.2.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,6 +33,7 @@ jobs:
       # Push generated files onto a new branch called gh-pages
       - name: Deploy jsDocs
         uses: peaceiris/actions-gh-pages@v3
+        if: ${{ github.ref == 'refs/heads/main' }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: .

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Personal note taking app that enables users to share their notes with other user
 
 ## View our deployed project!
 
-[https://cse110-fa22-group5.github.io/cse110-fa22-group5/source](https://cse110-fa22-group5.github.io/cse110-fa22-group5/source)
+[https://cse110-fa22-group5.github.io/cse110-fa22-group5/source/index.html](https://cse110-fa22-group5.github.io/cse110-fa22-group5/source/index.html)
 
 ## Meet our team!
 
@@ -20,7 +20,7 @@ Video and tutorial on how our project works.
 
 ## Documentation
 
-All documentation generated via JSDocs [here](https://cse110-fa22-group5.github.io/cse110-fa22-group5/jsdocs).
+All documentation generated via JSDocs [here](https://cse110-fa22-group5.github.io/cse110-fa22-group5/jsdocs/index.html).
 
 ## Running and Scripts
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Personal note taking app that enables users to share their notes with other user
 
 ## View our deployed project!
 
-[https://cse110-fa22-group5.github.io/cse110-fa22-group5/source/index.html](https://cse110-fa22-group5.github.io/cse110-fa22-group5/source/index.html)
+[https://cse110-fa22-group5.github.io/cse110-fa22-group5/source](https://cse110-fa22-group5.github.io/cse110-fa22-group5/source)
 
 ## Meet our team!
 
@@ -20,7 +20,7 @@ Video and tutorial on how our project works.
 
 ## Documentation
 
-All documentation via JSDocs or tbd.
+All documentation generated via JSDocs [here](https://cse110-fa22-group5.github.io/cse110-fa22-group5/jsdocs).
 
 ## Running and Scripts
 
@@ -46,6 +46,31 @@ npm run lint:fix
 
 List how to test our code (unit and E2E) and what we use to test.
 
+We use [Jest](https://jestjs.io/) for our backend unit testing (tests located in [./jestTesting](./jestTesting/)).
+
+Additionally, we use [Puppeteer](https://pptr.dev/) for end-to-end testing (tests located in [./puppeteerTesting](./puppeteerTesting/))
+
+To run unit and end-to-end tests, run
+
+```
+npm run test
+```
+
 ## Linting and Validation
 
 Validate our CSS, HTML, and Javascript files with linting and validation tools listed here.
+
+We use [ESLint](https://eslint.org/) and [Prettier](https://prettier.io/) to automatically check and fix code formatting and quality.
+
+To check and automatically fix code for linting and formatting, run
+
+```
+npm run lint:fix
+```
+
+To only check the code for linting and formatting errors, run
+```
+npm run lint:check
+```
+
+Finally, we validate our HTML using [HTML5 Validator](https://github.com/marketplace/actions/html5-validator) in our CI/CD pipeline.

--- a/jestTesting/sum.js
+++ b/jestTesting/sum.js
@@ -1,4 +1,0 @@
-function sum(a, b) {
-  return a + b;
-}
-module.exports = sum;

--- a/jestTesting/sum.test.js
+++ b/jestTesting/sum.test.js
@@ -1,5 +1,0 @@
-const sum = require('./sum');
-
-test('adds 1 + 2 to equal 3', () => {
-  expect(sum(1, 2)).toBe(3);
-});


### PR DESCRIPTION
- Generate jsDocs in the repo and push the repo to gh-pages
- Update README with necessary documentation
- From now, deploying GitHub Pages from gh-pages should mirror main, but with jsDocs automatically generated
- Deleted placeholder Jest tests
- Closes #30 
- Resolves changes brought up in #118, #115, #104